### PR TITLE
Auto package discovery for Laravel 5.5+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,12 @@
     },
     "license": "MIT",
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Devpark\\Transfers24\\Providers\\Transfers24ServiceProvider"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Od Laravel'a 5.5 nie trzeba już ręcznie dodawać Service Providera do `config/app.php`. W zamian wystarczy dodać odpowiednie pole w `composer.json`